### PR TITLE
WIP: Added support for i128/u128, but currently failing tests.

### DIFF
--- a/src/fields/primitive.rs
+++ b/src/fields/primitive.rs
@@ -129,10 +129,12 @@ int_field!(i8);
 int_field!(i16);
 int_field!(i32);
 int_field!(i64);
+int_field!(i128);
 int_field!(u8);
 int_field!(u16);
 int_field!(u32);
 int_field!(u64);
+int_field!(u128);
 
 /// Field type `[u8]`:
 /// This field represents an [open ended byte array](crate#open-ended-byte-arrays-u8).
@@ -449,6 +451,58 @@ mod tests {
     }
 
     #[test]
+    fn test_i128_littleendian() {
+        let mut storage = vec![0; 1024];
+
+        type Field1 = PrimitiveField<i128, LittleEndian, 5>;
+        type Field2 = PrimitiveField<i128, LittleEndian, 20>;
+
+        Field1::write(&mut storage, 10i128.pow(30));
+        Field2::write(&mut storage, -(10i128.pow(28)));
+
+        assert_eq!(
+            10i128.pow(30),
+            i128::from_le_bytes((&storage[5..21]).try_into().unwrap())
+        );
+        assert_eq!(
+            -(10i128.pow(28)),
+            i128::from_le_bytes((&storage[20..36]).try_into().unwrap())
+        );
+
+        assert_eq!(10i128.pow(30), Field1::read(&storage));
+        assert_eq!(-(10i128.pow(28)), Field2::read(&storage));
+
+        assert_eq!(16, PrimitiveField::<i128, LittleEndian, 5>::SIZE);
+        assert_eq!(16, PrimitiveField::<i128, LittleEndian, 5>::SIZE);
+    }
+
+    #[test]
+    fn test_i128_bigendian() {
+        let mut storage = vec![0; 1024];
+
+        type Field1 = PrimitiveField<i128, BigEndian, 5>;
+        type Field2 = PrimitiveField<i128, BigEndian, 20>;
+
+        Field1::write(&mut storage, 10i128.pow(30));
+        Field2::write(&mut storage, -(10i128.pow(28)));
+
+        assert_eq!(
+            10i128.pow(30),
+            i128::from_be_bytes((&storage[5..21]).try_into().unwrap())
+        );
+        assert_eq!(
+            -(10i128.pow(28)),
+            i128::from_be_bytes((&storage[20..36]).try_into().unwrap())
+        );
+
+        assert_eq!(10i128.pow(30), Field1::read(&storage));
+        assert_eq!(-(10i128.pow(28)), Field2::read(&storage));
+
+        assert_eq!(16, PrimitiveField::<i128, BigEndian, 5>::SIZE);
+        assert_eq!(16, PrimitiveField::<i128, BigEndian, 5>::SIZE);
+    }
+
+    #[test]
     fn test_u8_littleendian() {
         let mut storage = vec![0; 1024];
 
@@ -648,6 +702,58 @@ mod tests {
 
         assert_eq!(8, PrimitiveField::<u64, BigEndian, 5>::SIZE);
         assert_eq!(8, PrimitiveField::<u64, BigEndian, 5>::SIZE);
+    }
+
+    #[test]
+    fn test_u128_littleendian() {
+        let mut storage = vec![0; 1024];
+
+        type Field1 = PrimitiveField<u128, LittleEndian, 5>;
+        type Field2 = PrimitiveField<u128, LittleEndian, 20>;
+
+        Field1::write(&mut storage, 10u128.pow(30));
+        Field2::write(&mut storage, 10u128.pow(28));
+
+        assert_eq!(
+            10u128.pow(30),
+            u128::from_le_bytes((&storage[5..21]).try_into().unwrap())
+        );
+        assert_eq!(
+            10u128.pow(28),
+            u128::from_le_bytes((&storage[20..36]).try_into().unwrap())
+        );
+
+        assert_eq!(10u128.pow(30), Field1::read(&storage));
+        assert_eq!(10u128.pow(28), Field2::read(&storage));
+
+        assert_eq!(16, PrimitiveField::<u128, LittleEndian, 5>::SIZE);
+        assert_eq!(16, PrimitiveField::<u128, LittleEndian, 5>::SIZE);
+    }
+
+    #[test]
+    fn test_u128_bigendian() {
+        let mut storage = vec![0; 1024];
+
+        type Field1 = PrimitiveField<u128, BigEndian, 5>;
+        type Field2 = PrimitiveField<u128, BigEndian, 20>;
+
+        Field1::write(&mut storage, 10u128.pow(30));
+        Field2::write(&mut storage, 10u128.pow(28));
+
+        assert_eq!(
+            10u128.pow(30),
+            u128::from_be_bytes((&storage[5..21]).try_into().unwrap())
+        );
+        assert_eq!(
+            10u128.pow(28),
+            u128::from_be_bytes((&storage[20..36]).try_into().unwrap())
+        );
+
+        assert_eq!(10u128.pow(30), Field1::read(&storage));
+        assert_eq!(10u128.pow(28), Field2::read(&storage));
+
+        assert_eq!(16, PrimitiveField::<u128, BigEndian, 5>::SIZE);
+        assert_eq!(16, PrimitiveField::<u128, BigEndian, 5>::SIZE);
     }
 
     #[test]


### PR DESCRIPTION
This PR contains updates to support `*128`, but there is a test failure:

```bash
failures:

---- fields::primitive::tests::test_i128_bigendian stdout ----
thread 'fields::primitive::tests::test_i128_bigendian' panicked at 'assertion failed: `(left == right)`
  left: `1000000000000000000000000000000`,
 right: `1000000000000000000000000000255`', src/fields/primitive.rs:489:9
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace


failures:
    fields::primitive::tests::test_i128_bigendian

test result: FAILED. 72 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
```

Looks like -1 in the last byte, not sure why though.  