### PR TITLE
Ran `preen_rust.sh` across everything

### DIFF
--- a/src/fields/mod.rs
+++ b/src/fields/mod.rs
@@ -130,7 +130,7 @@ pub trait FieldCopyAccess: Field {
     /// Write the field to a given data region, assuming the defined layout, using the [Field] API.
     ///
     /// # Example:
-    ///         
+    ///
     /// ```
     /// use binary_layout::prelude::*;
     ///
@@ -178,7 +178,7 @@ pub trait FieldSliceAccess<'a>: Field {
     /// # Example:
     /// ```
     /// use binary_layout::prelude::*;
-    ///     
+    ///
     /// define_layout!(my_layout, LittleEndian, {
     ///     //... other fields ...
     ///     tail_data: [u8],

--- a/src/fields/primitive.rs
+++ b/src/fields/primitive.rs
@@ -58,12 +58,12 @@ macro_rules! int_field {
             doc_comment::doc_comment! {
                 concat! {"
                 Read the integer field from a given data region, assuming the defined layout, using the [Field] API.
-                
+
                 # Example:
-                
+
                 ```
                 use binary_layout::prelude::*;
-                    
+
                 define_layout!(my_layout, LittleEndian, {
                     //... other fields ...
                     some_integer_field: ", stringify!($type), "
@@ -90,12 +90,12 @@ macro_rules! int_field {
             doc_comment::doc_comment! {
                 concat! {"
                 Write the integer field to a given data region, assuming the defined layout, using the [Field] API.
-                
+
                 # Example:
-                
+
                 ```
                 use binary_layout::prelude::*;
-                    
+
                 define_layout!(my_layout, LittleEndian, {
                     //... other fields ...
                     some_integer_field: ", stringify!($type), "
@@ -336,7 +336,7 @@ impl<'a, E: Endianness, const OFFSET_: usize> FieldSliceAccess<'a>
     /// # Example:
     /// ```
     /// use binary_layout::prelude::*;
-    ///     
+    ///
     /// define_layout!(my_layout, LittleEndian, {
     ///     //... other fields ...
     ///     tail_data: [u8],
@@ -362,11 +362,11 @@ impl<'a, E: Endianness, const N: usize, const OFFSET_: usize> FieldSliceAccess<'
 
     /// Borrow the data in the byte array with read access using the [Field] API.
     /// See also [FieldSliceAccess::data].
-    ///  
+    ///
     /// # Example:
     /// ```
     /// use binary_layout::prelude::*;
-    ///     
+    ///
     /// define_layout!(my_layout, LittleEndian, {
     ///     //... other fields ...
     ///     some_field: [u8; 5],
@@ -383,11 +383,11 @@ impl<'a, E: Endianness, const N: usize, const OFFSET_: usize> FieldSliceAccess<'
 
     /// Borrow the data in the byte array with write access using the [Field] API.
     /// See also [FieldSliceAccess::data_mut]
-    ///  
+    ///
     /// # Example:
     /// ```
     /// use binary_layout::prelude::*;
-    ///     
+    ///
     /// define_layout!(my_layout, LittleEndian, {
     ///     //... other fields ...
     ///     some_field: [u8; 5],

--- a/src/view.rs
+++ b/src/view.rs
@@ -64,7 +64,7 @@ impl<S: AsRef<[u8]>, F: FieldCopyAccess> FieldView<S, F> {
     /// # Example
     /// ```
     /// use binary_layout::prelude::*;
-    ///                       
+    ///
     /// define_layout!(my_layout, LittleEndian, {
     ///   //... other fields ...
     ///   some_integer_field: i8
@@ -86,7 +86,7 @@ impl<S: AsMut<[u8]>, F: FieldCopyAccess> FieldView<S, F> {
     /// # Example
     /// ```
     /// use binary_layout::prelude::*;
-    ///                       
+    ///
     /// define_layout!(my_layout, LittleEndian, {
     ///   //... other fields ...
     ///   some_integer_field: i8
@@ -109,7 +109,7 @@ impl<'a, S: 'a + AsRef<[u8]>, F: FieldSliceAccess<'a>> FieldView<S, F> {
     /// # Example
     /// ```
     /// use binary_layout::prelude::*;
-    ///             
+    ///
     /// define_layout!(my_layout, LittleEndian, {
     ///   //... other fields ...
     ///   tail_data: [u8],
@@ -230,7 +230,7 @@ impl<
     /// # Example:
     /// ```
     /// use binary_layout::prelude::*;
-    ///     
+    ///
     /// define_layout!(my_layout, LittleEndian, {
     ///   another_field: u64,
     ///   tail_data: [u8],


### PR DESCRIPTION
This is just a style pull.  I ran my custom `preen_rust.sh` script across everything, which both formats the code and removes trailing whitespace from each line.