### PR TITLE
Fix no_std compatibility

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -1,6 +1,7 @@
 3.1.0
 ------
 - Fixed-size array fields (i.e. `[u8; N]`) now return `&[u8; N]` instead of `&[u8]` when accessed
+- Fix no_std compatibility
 
 3.0.0
 ------

--- a/src/fields/primitive/slice_access.rs
+++ b/src/fields/primitive/slice_access.rs
@@ -1,4 +1,4 @@
-use std::convert::TryFrom;
+use core::convert::TryFrom;
 
 use super::super::{Field, StorageIntoFieldView, StorageToFieldView};
 use super::PrimitiveField;

--- a/src/utils/data.rs
+++ b/src/utils/data.rs
@@ -1,5 +1,5 @@
-use std::fmt::Debug;
-use std::ops::{Bound, Deref, DerefMut, Range, RangeBounds};
+use core::fmt::Debug;
+use core::ops::{Bound, Deref, DerefMut, Range, RangeBounds};
 
 /// An instance of data owns a block of data. It implements `AsRef<[u8]>` and `AsMut<[u8]>` to allow
 /// borrowing that data, and it has a [Data::into_subregion] function that cuts away bytes at either


### PR DESCRIPTION
Did not build for #[no_std] environment, as it referenced traits from std::. Replaced it with equivalent ones from core::