### PR TITLE
Added NativeEndian support

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ define_layout!(deep_nesting, LittleEndian, {
 define_layout!(header, BigEndian, {
     field1: i16,
 });
-define_layout!(middle, BigEndian, {
+define_layout!(middle, NativeEndian, {
     deep: deep_nesting::NestedView,
     field1: u16,
 });

--- a/src/endianness.rs
+++ b/src/endianness.rs
@@ -2,6 +2,7 @@
 pub enum EndianKind {
     Big,
     Little,
+    Native,
 }
 
 /// This marker trait represents the endianness used in a layout for accessing primitive integer fields.
@@ -10,7 +11,7 @@ pub trait Endianness {
     const KIND: EndianKind;
 }
 
-/// This is a marker type to mark layouts using big endian encoding. The alternative is [LittleEndian] encoding.
+/// This is a marker type to mark layouts using big endian encoding. The alternative is [LittleEndian] and [NativeEndian] encoding.
 ///
 /// # Example
 /// ```
@@ -26,7 +27,7 @@ impl Endianness for BigEndian {
     const KIND: EndianKind = EndianKind::Big;
 }
 
-/// This is a marker type to mark layouts using little endian encoding. The alternative is [BigEndian] encoding.
+/// This is a marker type to mark layouts using little endian encoding. The alternative is [BigEndian] and [NativeEndian] encoding.
 ///
 /// # Example
 /// ```
@@ -40,4 +41,20 @@ impl Endianness for BigEndian {
 pub struct LittleEndian {}
 impl Endianness for LittleEndian {
     const KIND: EndianKind = EndianKind::Little;
+}
+
+/// This is a marker type to mark layouts using native endian encoding. The alternative is [BigEndian] and [LittleEndian] encoding.
+///
+/// # Example
+/// ```
+/// use binary_layout::prelude::*;
+///
+/// define_layout!(my_layout, NativeEndian, {
+///   field1: i16,
+///   field2: u32,
+/// });
+/// ```
+pub struct NativeEndian {}
+impl Endianness for NativeEndian {
+    const KIND: EndianKind = EndianKind::Native;
 }

--- a/src/fields/primitive/copy_access.rs
+++ b/src/fields/primitive/copy_access.rs
@@ -135,6 +135,7 @@ macro_rules! int_field {
                     match E::KIND {
                         EndianKind::Big => <$type>::from_be_bytes(value),
                         EndianKind::Little => <$type>::from_le_bytes(value),
+                        EndianKind::Native => <$type>::from_ne_bytes(value)
                     }
                 }
             }
@@ -164,6 +165,7 @@ macro_rules! int_field {
                     let value_as_bytes = match E::KIND {
                         EndianKind::Big => value.to_be_bytes(),
                         EndianKind::Little => value.to_le_bytes(),
+                        EndianKind::Native => value.to_ne_bytes(),
                     };
                     storage[Self::OFFSET..(Self::OFFSET + core::mem::size_of::<$type>())]
                         .copy_from_slice(&value_as_bytes);
@@ -229,6 +231,7 @@ macro_rules! float_field {
                     match E::KIND {
                         EndianKind::Big => <$type>::from_be_bytes(value),
                         EndianKind::Little => <$type>::from_le_bytes(value),
+                        EndianKind::Native => <$type>::from_ne_bytes(value),
                     }
                 }
             }
@@ -265,6 +268,7 @@ macro_rules! float_field {
                     let value_as_bytes = match E::KIND {
                         EndianKind::Big => value.to_be_bytes(),
                         EndianKind::Little => value.to_le_bytes(),
+                        EndianKind::Native => value.to_ne_bytes(),
                     };
                     storage[Self::OFFSET..(Self::OFFSET + core::mem::size_of::<$type>())]
                         .copy_from_slice(&value_as_bytes);
@@ -406,6 +410,29 @@ mod tests {
     }
 
     #[test]
+    fn test_i8_nativeendian() {
+        let mut storage = vec![0; 1024];
+
+        type Field1 = PrimitiveField<i8, NativeEndian, 5>;
+        type Field2 = PrimitiveField<i8, NativeEndian, 20>;
+
+        Field1::write(&mut storage, 50);
+        Field2::write(&mut storage, -20);
+
+        assert_eq!(50, Field1::read(&storage));
+        assert_eq!(-20, Field2::read(&storage));
+
+        assert_eq!(50, i8::from_ne_bytes((&storage[5..6]).try_into().unwrap()));
+        assert_eq!(
+            -20,
+            i8::from_ne_bytes((&storage[20..21]).try_into().unwrap())
+        );
+
+        assert_eq!(Some(1), PrimitiveField::<i8, NativeEndian, 5>::SIZE);
+        assert_eq!(Some(1), PrimitiveField::<i8, NativeEndian, 5>::SIZE);
+    }
+
+    #[test]
     fn test_i16_littleendian() {
         let mut storage = vec![0; 1024];
 
@@ -455,6 +482,32 @@ mod tests {
 
         assert_eq!(Some(2), PrimitiveField::<i16, BigEndian, 5>::SIZE);
         assert_eq!(Some(2), PrimitiveField::<i16, BigEndian, 5>::SIZE);
+    }
+
+    #[test]
+    fn test_i16_nativeendian() {
+        let mut storage = vec![0; 1024];
+
+        type Field1 = PrimitiveField<i16, NativeEndian, 5>;
+        type Field2 = PrimitiveField<i16, NativeEndian, 20>;
+
+        Field1::write(&mut storage, 500);
+        Field2::write(&mut storage, -2000);
+
+        assert_eq!(
+            500,
+            i16::from_ne_bytes((&storage[5..7]).try_into().unwrap())
+        );
+        assert_eq!(
+            -2000,
+            i16::from_ne_bytes((&storage[20..22]).try_into().unwrap())
+        );
+
+        assert_eq!(500, Field1::read(&storage));
+        assert_eq!(-2000, Field2::read(&storage));
+
+        assert_eq!(Some(2), PrimitiveField::<i16, NativeEndian, 5>::SIZE);
+        assert_eq!(Some(2), PrimitiveField::<i16, NativeEndian, 5>::SIZE);
     }
 
     #[test]
@@ -510,6 +563,32 @@ mod tests {
     }
 
     #[test]
+    fn test_i32_nativeendian() {
+        let mut storage = vec![0; 1024];
+
+        type Field1 = PrimitiveField<i32, NativeEndian, 5>;
+        type Field2 = PrimitiveField<i32, NativeEndian, 20>;
+
+        Field1::write(&mut storage, 10i32.pow(8));
+        Field2::write(&mut storage, -(10i32.pow(7)));
+
+        assert_eq!(
+            10i32.pow(8),
+            i32::from_ne_bytes((&storage[5..9]).try_into().unwrap())
+        );
+        assert_eq!(
+            -(10i32.pow(7)),
+            i32::from_ne_bytes((&storage[20..24]).try_into().unwrap())
+        );
+
+        assert_eq!(10i32.pow(8), Field1::read(&storage));
+        assert_eq!(-(10i32.pow(7)), Field2::read(&storage));
+
+        assert_eq!(Some(4), PrimitiveField::<i32, NativeEndian, 5>::SIZE);
+        assert_eq!(Some(4), PrimitiveField::<i32, NativeEndian, 5>::SIZE);
+    }
+
+    #[test]
     fn test_i64_littleendian() {
         let mut storage = vec![0; 1024];
 
@@ -559,6 +638,32 @@ mod tests {
 
         assert_eq!(Some(8), PrimitiveField::<i64, BigEndian, 5>::SIZE);
         assert_eq!(Some(8), PrimitiveField::<i64, BigEndian, 5>::SIZE);
+    }
+
+    #[test]
+    fn test_i64_nativeendian() {
+        let mut storage = vec![0; 1024];
+
+        type Field1 = PrimitiveField<i64, NativeEndian, 5>;
+        type Field2 = PrimitiveField<i64, NativeEndian, 20>;
+
+        Field1::write(&mut storage, 10i64.pow(15));
+        Field2::write(&mut storage, -(10i64.pow(14)));
+
+        assert_eq!(
+            10i64.pow(15),
+            i64::from_ne_bytes((&storage[5..13]).try_into().unwrap())
+        );
+        assert_eq!(
+            -(10i64.pow(14)),
+            i64::from_ne_bytes((&storage[20..28]).try_into().unwrap())
+        );
+
+        assert_eq!(10i64.pow(15), Field1::read(&storage));
+        assert_eq!(-(10i64.pow(14)), Field2::read(&storage));
+
+        assert_eq!(Some(8), PrimitiveField::<i64, NativeEndian, 5>::SIZE);
+        assert_eq!(Some(8), PrimitiveField::<i64, NativeEndian, 5>::SIZE);
     }
 
     #[test]
@@ -614,6 +719,32 @@ mod tests {
     }
 
     #[test]
+    fn test_i128_nativeendian() {
+        let mut storage = vec![0; 1024];
+
+        type Field1 = PrimitiveField<i128, NativeEndian, 5>;
+        type Field2 = PrimitiveField<i128, NativeEndian, 200>;
+
+        Field1::write(&mut storage, 10i128.pow(30));
+        Field2::write(&mut storage, -(10i128.pow(28)));
+
+        assert_eq!(
+            10i128.pow(30),
+            i128::from_ne_bytes((&storage[5..21]).try_into().unwrap())
+        );
+        assert_eq!(
+            -(10i128.pow(28)),
+            i128::from_ne_bytes((&storage[200..216]).try_into().unwrap())
+        );
+
+        assert_eq!(10i128.pow(30), Field1::read(&storage));
+        assert_eq!(-(10i128.pow(28)), Field2::read(&storage));
+
+        assert_eq!(Some(16), PrimitiveField::<i128, NativeEndian, 5>::SIZE);
+        assert_eq!(Some(16), PrimitiveField::<i128, NativeEndian, 5>::SIZE);
+    }
+
+    #[test]
     fn test_u8_littleendian() {
         let mut storage = vec![0; 1024];
 
@@ -657,6 +788,29 @@ mod tests {
 
         assert_eq!(Some(1), PrimitiveField::<u8, BigEndian, 5>::SIZE);
         assert_eq!(Some(1), PrimitiveField::<u8, BigEndian, 5>::SIZE);
+    }
+
+    #[test]
+    fn test_u8_nativeendian() {
+        let mut storage = vec![0; 1024];
+
+        type Field1 = PrimitiveField<u8, NativeEndian, 5>;
+        type Field2 = PrimitiveField<u8, NativeEndian, 20>;
+
+        Field1::write(&mut storage, 50);
+        Field2::write(&mut storage, 20);
+
+        assert_eq!(50, Field1::read(&storage));
+        assert_eq!(20, Field2::read(&storage));
+
+        assert_eq!(50, u8::from_ne_bytes((&storage[5..6]).try_into().unwrap()));
+        assert_eq!(
+            20,
+            u8::from_ne_bytes((&storage[20..21]).try_into().unwrap())
+        );
+
+        assert_eq!(Some(1), PrimitiveField::<u8, NativeEndian, 5>::SIZE);
+        assert_eq!(Some(1), PrimitiveField::<u8, NativeEndian, 5>::SIZE);
     }
 
     #[test]
@@ -712,6 +866,32 @@ mod tests {
     }
 
     #[test]
+    fn test_u16_nativeendian() {
+        let mut storage = vec![0; 1024];
+
+        type Field1 = PrimitiveField<u16, NativeEndian, 5>;
+        type Field2 = PrimitiveField<u16, NativeEndian, 20>;
+
+        Field1::write(&mut storage, 500);
+        Field2::write(&mut storage, 2000);
+
+        assert_eq!(
+            500,
+            u16::from_ne_bytes((&storage[5..7]).try_into().unwrap())
+        );
+        assert_eq!(
+            2000,
+            u16::from_ne_bytes((&storage[20..22]).try_into().unwrap())
+        );
+
+        assert_eq!(500, Field1::read(&storage));
+        assert_eq!(2000, Field2::read(&storage));
+
+        assert_eq!(Some(2), PrimitiveField::<u16, NativeEndian, 5>::SIZE);
+        assert_eq!(Some(2), PrimitiveField::<u16, NativeEndian, 5>::SIZE);
+    }
+
+    #[test]
     fn test_u32_littleendian() {
         let mut storage = vec![0; 1024];
 
@@ -761,6 +941,32 @@ mod tests {
 
         assert_eq!(Some(4), PrimitiveField::<u32, BigEndian, 5>::SIZE);
         assert_eq!(Some(4), PrimitiveField::<u32, BigEndian, 5>::SIZE);
+    }
+
+    #[test]
+    fn test_u32_nativeendian() {
+        let mut storage = vec![0; 1024];
+
+        type Field1 = PrimitiveField<u32, NativeEndian, 5>;
+        type Field2 = PrimitiveField<u32, NativeEndian, 20>;
+
+        Field1::write(&mut storage, 10u32.pow(8));
+        Field2::write(&mut storage, 10u32.pow(7));
+
+        assert_eq!(
+            10u32.pow(8),
+            u32::from_ne_bytes((&storage[5..9]).try_into().unwrap())
+        );
+        assert_eq!(
+            10u32.pow(7),
+            u32::from_ne_bytes((&storage[20..24]).try_into().unwrap())
+        );
+
+        assert_eq!(10u32.pow(8), Field1::read(&storage));
+        assert_eq!(10u32.pow(7), Field2::read(&storage));
+
+        assert_eq!(Some(4), PrimitiveField::<u32, NativeEndian, 5>::SIZE);
+        assert_eq!(Some(4), PrimitiveField::<u32, NativeEndian, 5>::SIZE);
     }
 
     #[test]
@@ -816,6 +1022,32 @@ mod tests {
     }
 
     #[test]
+    fn test_u64_nativeendian() {
+        let mut storage = vec![0; 1024];
+
+        type Field1 = PrimitiveField<u64, NativeEndian, 5>;
+        type Field2 = PrimitiveField<u64, NativeEndian, 20>;
+
+        Field1::write(&mut storage, 10u64.pow(15));
+        Field2::write(&mut storage, 10u64.pow(14));
+
+        assert_eq!(
+            10u64.pow(15),
+            u64::from_ne_bytes((&storage[5..13]).try_into().unwrap())
+        );
+        assert_eq!(
+            10u64.pow(14),
+            u64::from_ne_bytes((&storage[20..28]).try_into().unwrap())
+        );
+
+        assert_eq!(10u64.pow(15), Field1::read(&storage));
+        assert_eq!(10u64.pow(14), Field2::read(&storage));
+
+        assert_eq!(Some(8), PrimitiveField::<u64, NativeEndian, 5>::SIZE);
+        assert_eq!(Some(8), PrimitiveField::<u64, NativeEndian, 5>::SIZE);
+    }
+
+    #[test]
     fn test_u128_littleendian() {
         let mut storage = vec![0; 1024];
 
@@ -865,6 +1097,32 @@ mod tests {
 
         assert_eq!(Some(16), PrimitiveField::<u128, BigEndian, 5>::SIZE);
         assert_eq!(Some(16), PrimitiveField::<u128, BigEndian, 5>::SIZE);
+    }
+
+    #[test]
+    fn test_u128_nativeendian() {
+        let mut storage = vec![0; 1024];
+
+        type Field1 = PrimitiveField<u128, NativeEndian, 5>;
+        type Field2 = PrimitiveField<u128, NativeEndian, 200>;
+
+        Field1::write(&mut storage, 10u128.pow(30));
+        Field2::write(&mut storage, 10u128.pow(28));
+
+        assert_eq!(
+            10u128.pow(30),
+            u128::from_ne_bytes((&storage[5..21]).try_into().unwrap())
+        );
+        assert_eq!(
+            10u128.pow(28),
+            u128::from_ne_bytes((&storage[200..216]).try_into().unwrap())
+        );
+
+        assert_eq!(10u128.pow(30), Field1::read(&storage));
+        assert_eq!(10u128.pow(28), Field2::read(&storage));
+
+        assert_eq!(Some(16), PrimitiveField::<u128, NativeEndian, 5>::SIZE);
+        assert_eq!(Some(16), PrimitiveField::<u128, NativeEndian, 5>::SIZE);
     }
 
     #[test]
@@ -920,6 +1178,32 @@ mod tests {
     }
 
     #[test]
+    fn test_f32_nativeendian() {
+        let mut storage = vec![0; 1024];
+
+        type Field1 = PrimitiveField<f32, NativeEndian, 5>;
+        type Field2 = PrimitiveField<f32, NativeEndian, 20>;
+
+        Field1::write(&mut storage, 10f32.powf(8.31));
+        Field2::write(&mut storage, -(10f32.powf(7.31)));
+
+        assert_eq!(
+            10f32.powf(8.31),
+            f32::from_ne_bytes((&storage[5..9]).try_into().unwrap())
+        );
+        assert_eq!(
+            -(10f32.powf(7.31)),
+            f32::from_ne_bytes((&storage[20..24]).try_into().unwrap())
+        );
+
+        assert_eq!(10f32.powf(8.31), Field1::read(&storage));
+        assert_eq!(-(10f32.powf(7.31)), Field2::read(&storage));
+
+        assert_eq!(Some(4), PrimitiveField::<f32, NativeEndian, 5>::SIZE);
+        assert_eq!(Some(4), PrimitiveField::<f32, NativeEndian, 5>::SIZE);
+    }
+
+    #[test]
     fn test_f64_littleendian() {
         let mut storage = vec![0; 1024];
 
@@ -971,6 +1255,32 @@ mod tests {
         assert_eq!(Some(8), PrimitiveField::<f64, BigEndian, 5>::SIZE);
     }
 
+    #[test]
+    fn test_f64_nativeendian() {
+        let mut storage = vec![0; 1024];
+
+        type Field1 = PrimitiveField<f64, NativeEndian, 5>;
+        type Field2 = PrimitiveField<f64, NativeEndian, 20>;
+
+        Field1::write(&mut storage, 10f64.powf(15.31));
+        Field2::write(&mut storage, -(10f64.powf(15.31)));
+
+        assert_eq!(
+            10f64.powf(15.31),
+            f64::from_ne_bytes((&storage[5..13]).try_into().unwrap())
+        );
+        assert_eq!(
+            -(10f64.powf(15.31)),
+            f64::from_ne_bytes((&storage[20..28]).try_into().unwrap())
+        );
+
+        assert_eq!(10f64.powf(15.31), Field1::read(&storage));
+        assert_eq!(-(10f64.powf(15.31)), Field2::read(&storage));
+
+        assert_eq!(Some(8), PrimitiveField::<f64, NativeEndian, 5>::SIZE);
+        assert_eq!(Some(8), PrimitiveField::<f64, NativeEndian, 5>::SIZE);
+    }
+
     #[allow(clippy::unit_cmp)]
     #[test]
     fn test_unit_bigendian() {
@@ -1009,6 +1319,28 @@ mod tests {
 
         assert_eq!(Some(0), PrimitiveField::<(), LittleEndian, 5>::SIZE);
         assert_eq!(Some(0), PrimitiveField::<(), LittleEndian, 20>::SIZE);
+
+        // Zero-sized types do not mutate the storage, so it should remain
+        // unchanged for all of time.
+        assert_eq!(storage, vec![0; 1024]);
+    }
+
+    #[allow(clippy::unit_cmp)]
+    #[test]
+    fn test_unit_nativeendian() {
+        let mut storage = vec![0; 1024];
+
+        type Field1 = PrimitiveField<(), NativeEndian, 5>;
+        type Field2 = PrimitiveField<(), NativeEndian, 20>;
+
+        Field1::write(&mut storage, ());
+        Field2::write(&mut storage, ());
+
+        assert_eq!((), Field1::read(&storage));
+        assert_eq!((), Field2::read(&storage));
+
+        assert_eq!(Some(0), PrimitiveField::<(), NativeEndian, 5>::SIZE);
+        assert_eq!(Some(0), PrimitiveField::<(), NativeEndian, 20>::SIZE);
 
         // Zero-sized types do not mutate the storage, so it should remain
         // unchanged for all of time.

--- a/src/fields/primitive/slice_access.rs
+++ b/src/fields/primitive/slice_access.rs
@@ -249,12 +249,15 @@ mod tests {
 
         type Field1 = PrimitiveField<[u8], LittleEndian, 5>;
         type Field2 = PrimitiveField<[u8], BigEndian, 7>;
+        type Field3 = PrimitiveField<[u8], NativeEndian, 9>;
 
         Field1::data_mut(&mut storage)[..5].copy_from_slice(&[10, 20, 30, 40, 50]);
         Field2::data_mut(&mut storage)[..5].copy_from_slice(&[60, 70, 80, 90, 100]);
+        Field3::data_mut(&mut storage)[..5].copy_from_slice(&[110, 120, 130, 140, 150]);
 
-        assert_eq!(&[10, 20, 60, 70, 80], &Field1::data(&storage)[..5]);
-        assert_eq!(&[60, 70, 80, 90, 100], &Field2::data(&storage)[..5]);
+        assert_eq!(&[10, 20, 60, 70, 110], &Field1::data(&storage)[..5]);
+        assert_eq!(&[60, 70, 110, 120, 130], &Field2::data(&storage)[..5]);
+        assert_eq!(&[110, 120, 130, 140, 150], &Field3::data(&storage)[..5]);
 
         // Check types are correct
         let _a: &[u8] = Field1::data(&storage);
@@ -267,15 +270,19 @@ mod tests {
 
         type Field1 = PrimitiveField<[u8; 2], LittleEndian, 5>;
         type Field2 = PrimitiveField<[u8; 5], BigEndian, 6>;
+        type Field3 = PrimitiveField<[u8; 5], NativeEndian, 7>;
 
         Field1::data_mut(&mut storage).copy_from_slice(&[10, 20]);
         Field2::data_mut(&mut storage).copy_from_slice(&[60, 70, 80, 90, 100]);
+        Field3::data_mut(&mut storage).copy_from_slice(&[60, 70, 80, 90, 100]);
 
         assert_eq!(&[10, 60], Field1::data(&storage));
-        assert_eq!(&[60, 70, 80, 90, 100], Field2::data(&storage));
+        assert_eq!(&[60, 60, 70, 80, 90], Field2::data(&storage));
+        assert_eq!(&[60, 70, 80, 90, 100], Field3::data(&storage));
 
         assert_eq!(Some(2), PrimitiveField::<[u8; 2], LittleEndian, 5>::SIZE);
         assert_eq!(Some(5), PrimitiveField::<[u8; 5], BigEndian, 5>::SIZE);
+        assert_eq!(Some(5), PrimitiveField::<[u8; 5], NativeEndian, 5>::SIZE);
 
         // Check types are correct
         let _a: &[u8; 2] = Field1::data(&storage);

--- a/src/fields/wrapped.rs
+++ b/src/fields/wrapped.rs
@@ -43,7 +43,7 @@ pub trait LayoutAs<U> {
     fn write(v: Self) -> U;
 }
 
-/// A [WrappedField] is a [Field] that, unlike [PrimitiveField](crate::PrimitiveField), does not directly represents a primitive type.
+/// A [WrappedField] is a [Field] that, unlike [PrimitiveField](crate::PrimitiveField), does not directly represent a primitive type.
 /// Instead, it represents a wrapper type that can be converted to/from a primitive type using the [LayoutAs] trait.
 /// See [Field] for more info on this API.
 ///
@@ -277,6 +277,35 @@ mod tests {
     }
 
     #[test]
+    fn test_i8_nativeendian() {
+        let mut storage = vec![0; 1024];
+
+        type Field1 = WrappedField<i8, Wrapped<i8>, PrimitiveField<i8, NativeEndian, 5>>;
+        type Field2 = WrappedField<i8, Wrapped<i8>, PrimitiveField<i8, NativeEndian, 20>>;
+
+        Field1::write(&mut storage, Wrapped(50));
+        Field2::write(&mut storage, Wrapped(-20));
+
+        assert_eq!(Wrapped(50), Field1::read(&storage));
+        assert_eq!(Wrapped(-20), Field2::read(&storage));
+
+        assert_eq!(50, i8::from_ne_bytes((&storage[5..6]).try_into().unwrap()));
+        assert_eq!(
+            -20,
+            i8::from_ne_bytes((&storage[20..21]).try_into().unwrap())
+        );
+
+        assert_eq!(
+            Some(1),
+            WrappedField::<i8, Wrapped<i8>, PrimitiveField::<i8, NativeEndian, 5>>::SIZE
+        );
+        assert_eq!(
+            Some(1),
+            WrappedField::<i8, Wrapped<i8>, PrimitiveField::<i8, NativeEndian, 5>>::SIZE
+        );
+    }
+
+    #[test]
     fn test_i16_littleendian() {
         let mut storage = vec![0; 1024];
 
@@ -337,6 +366,38 @@ mod tests {
         assert_eq!(
             Some(2),
             WrappedField::<i16, Wrapped<i16>, PrimitiveField::<i16, BigEndian, 5>>::SIZE
+        );
+    }
+
+    #[test]
+    fn test_i16_nativeendian() {
+        let mut storage = vec![0; 1024];
+
+        type Field1 = WrappedField<i16, Wrapped<i16>, PrimitiveField<i16, NativeEndian, 5>>;
+        type Field2 = WrappedField<i16, Wrapped<i16>, PrimitiveField<i16, NativeEndian, 20>>;
+
+        Field1::write(&mut storage, Wrapped(500));
+        Field2::write(&mut storage, Wrapped(-2000));
+
+        assert_eq!(
+            500,
+            i16::from_ne_bytes((&storage[5..7]).try_into().unwrap())
+        );
+        assert_eq!(
+            -2000,
+            i16::from_ne_bytes((&storage[20..22]).try_into().unwrap())
+        );
+
+        assert_eq!(Wrapped(500), Field1::read(&storage));
+        assert_eq!(Wrapped(-2000), Field2::read(&storage));
+
+        assert_eq!(
+            Some(2),
+            WrappedField::<i16, Wrapped<i16>, PrimitiveField::<i16, NativeEndian, 5>>::SIZE
+        );
+        assert_eq!(
+            Some(2),
+            WrappedField::<i16, Wrapped<i16>, PrimitiveField::<i16, NativeEndian, 5>>::SIZE
         );
     }
 
@@ -405,6 +466,38 @@ mod tests {
     }
 
     #[test]
+    fn test_i32_nativeendian() {
+        let mut storage = vec![0; 1024];
+
+        type Field1 = WrappedField<i32, Wrapped<i32>, PrimitiveField<i32, NativeEndian, 5>>;
+        type Field2 = WrappedField<i32, Wrapped<i32>, PrimitiveField<i32, NativeEndian, 20>>;
+
+        Field1::write(&mut storage, Wrapped(10i32.pow(8)));
+        Field2::write(&mut storage, Wrapped(-(10i32.pow(7))));
+
+        assert_eq!(
+            10i32.pow(8),
+            i32::from_ne_bytes((&storage[5..9]).try_into().unwrap())
+        );
+        assert_eq!(
+            -(10i32.pow(7)),
+            i32::from_ne_bytes((&storage[20..24]).try_into().unwrap())
+        );
+
+        assert_eq!(Wrapped(10i32.pow(8)), Field1::read(&storage));
+        assert_eq!(Wrapped(-(10i32.pow(7))), Field2::read(&storage));
+
+        assert_eq!(
+            Some(4),
+            WrappedField::<i32, Wrapped<i32>, PrimitiveField::<i32, NativeEndian, 5>>::SIZE
+        );
+        assert_eq!(
+            Some(4),
+            WrappedField::<i32, Wrapped<i32>, PrimitiveField::<i32, NativeEndian, 5>>::SIZE
+        );
+    }
+
+    #[test]
     fn test_i64_littleendian() {
         let mut storage = vec![0; 1024];
 
@@ -465,6 +558,38 @@ mod tests {
         assert_eq!(
             Some(8),
             WrappedField::<i64, Wrapped<i64>, PrimitiveField::<i64, BigEndian, 5>>::SIZE
+        );
+    }
+
+    #[test]
+    fn test_i64_nativeendian() {
+        let mut storage = vec![0; 1024];
+
+        type Field1 = WrappedField<i64, Wrapped<i64>, PrimitiveField<i64, NativeEndian, 5>>;
+        type Field2 = WrappedField<i64, Wrapped<i64>, PrimitiveField<i64, NativeEndian, 20>>;
+
+        Field1::write(&mut storage, Wrapped(10i64.pow(15)));
+        Field2::write(&mut storage, Wrapped(-(10i64.pow(14))));
+
+        assert_eq!(
+            10i64.pow(15),
+            i64::from_ne_bytes((&storage[5..13]).try_into().unwrap())
+        );
+        assert_eq!(
+            -(10i64.pow(14)),
+            i64::from_ne_bytes((&storage[20..28]).try_into().unwrap())
+        );
+
+        assert_eq!(Wrapped(10i64.pow(15)), Field1::read(&storage));
+        assert_eq!(Wrapped(-(10i64.pow(14))), Field2::read(&storage));
+
+        assert_eq!(
+            Some(8),
+            WrappedField::<i64, Wrapped<i64>, PrimitiveField::<i64, NativeEndian, 5>>::SIZE
+        );
+        assert_eq!(
+            Some(8),
+            WrappedField::<i64, Wrapped<i64>, PrimitiveField::<i64, NativeEndian, 5>>::SIZE
         );
     }
 
@@ -533,6 +658,38 @@ mod tests {
     }
 
     #[test]
+    fn test_i128_nativeendian() {
+        let mut storage = vec![0; 1024];
+
+        type Field1 = WrappedField<i128, Wrapped<i128>, PrimitiveField<i128, NativeEndian, 5>>;
+        type Field2 = WrappedField<i128, Wrapped<i128>, PrimitiveField<i128, NativeEndian, 200>>;
+
+        Field1::write(&mut storage, Wrapped(10i128.pow(30)));
+        Field2::write(&mut storage, Wrapped(-(10i128.pow(28))));
+
+        assert_eq!(
+            10i128.pow(30),
+            i128::from_ne_bytes((&storage[5..21]).try_into().unwrap())
+        );
+        assert_eq!(
+            -(10i128.pow(28)),
+            i128::from_ne_bytes((&storage[200..216]).try_into().unwrap())
+        );
+
+        assert_eq!(Wrapped(10i128.pow(30)), Field1::read(&storage));
+        assert_eq!(Wrapped(-(10i128.pow(28))), Field2::read(&storage));
+
+        assert_eq!(
+            Some(16),
+            WrappedField::<i128, Wrapped<i128>, PrimitiveField::<i128, NativeEndian, 5>>::SIZE
+        );
+        assert_eq!(
+            Some(16),
+            WrappedField::<i128, Wrapped<i128>, PrimitiveField::<i128, NativeEndian, 5>>::SIZE
+        );
+    }
+
+    #[test]
     fn test_u8_littleendian() {
         let mut storage = vec![0; 1024];
 
@@ -587,6 +744,35 @@ mod tests {
         assert_eq!(
             Some(1),
             WrappedField::<u8, Wrapped<u8>, PrimitiveField::<u8, BigEndian, 5>>::SIZE
+        );
+    }
+
+    #[test]
+    fn test_u8_nativeendian() {
+        let mut storage = vec![0; 1024];
+
+        type Field1 = WrappedField<u8, Wrapped<u8>, PrimitiveField<u8, NativeEndian, 5>>;
+        type Field2 = WrappedField<u8, Wrapped<u8>, PrimitiveField<u8, NativeEndian, 20>>;
+
+        Field1::write(&mut storage, Wrapped(50));
+        Field2::write(&mut storage, Wrapped(20));
+
+        assert_eq!(Wrapped(50), Field1::read(&storage));
+        assert_eq!(Wrapped(20), Field2::read(&storage));
+
+        assert_eq!(50, u8::from_ne_bytes((&storage[5..6]).try_into().unwrap()));
+        assert_eq!(
+            20,
+            u8::from_ne_bytes((&storage[20..21]).try_into().unwrap())
+        );
+
+        assert_eq!(
+            Some(1),
+            WrappedField::<u8, Wrapped<u8>, PrimitiveField::<u8, NativeEndian, 5>>::SIZE
+        );
+        assert_eq!(
+            Some(1),
+            WrappedField::<u8, Wrapped<u8>, PrimitiveField::<u8, NativeEndian, 5>>::SIZE
         );
     }
 
@@ -655,6 +841,38 @@ mod tests {
     }
 
     #[test]
+    fn test_u16_nativeendian() {
+        let mut storage = vec![0; 1024];
+
+        type Field1 = WrappedField<u16, Wrapped<u16>, PrimitiveField<u16, NativeEndian, 5>>;
+        type Field2 = WrappedField<u16, Wrapped<u16>, PrimitiveField<u16, NativeEndian, 20>>;
+
+        Field1::write(&mut storage, Wrapped(500));
+        Field2::write(&mut storage, Wrapped(2000));
+
+        assert_eq!(
+            500,
+            u16::from_ne_bytes((&storage[5..7]).try_into().unwrap())
+        );
+        assert_eq!(
+            2000,
+            u16::from_ne_bytes((&storage[20..22]).try_into().unwrap())
+        );
+
+        assert_eq!(Wrapped(500), Field1::read(&storage));
+        assert_eq!(Wrapped(2000), Field2::read(&storage));
+
+        assert_eq!(
+            Some(2),
+            WrappedField::<u16, Wrapped<u16>, PrimitiveField::<u16, NativeEndian, 5>>::SIZE
+        );
+        assert_eq!(
+            Some(2),
+            WrappedField::<u16, Wrapped<u16>, PrimitiveField::<u16, NativeEndian, 5>>::SIZE
+        );
+    }
+
+    #[test]
     fn test_u32_littleendian() {
         let mut storage = vec![0; 1024];
 
@@ -715,6 +933,38 @@ mod tests {
         assert_eq!(
             Some(4),
             WrappedField::<u32, Wrapped<u32>, PrimitiveField::<u32, BigEndian, 5>>::SIZE
+        );
+    }
+
+    #[test]
+    fn test_u32_nativeendian() {
+        let mut storage = vec![0; 1024];
+
+        type Field1 = WrappedField<u32, Wrapped<u32>, PrimitiveField<u32, NativeEndian, 5>>;
+        type Field2 = WrappedField<u32, Wrapped<u32>, PrimitiveField<u32, NativeEndian, 20>>;
+
+        Field1::write(&mut storage, Wrapped(10u32.pow(8)));
+        Field2::write(&mut storage, Wrapped(10u32.pow(7)));
+
+        assert_eq!(
+            10u32.pow(8),
+            u32::from_ne_bytes((&storage[5..9]).try_into().unwrap())
+        );
+        assert_eq!(
+            10u32.pow(7),
+            u32::from_ne_bytes((&storage[20..24]).try_into().unwrap())
+        );
+
+        assert_eq!(Wrapped(10u32.pow(8)), Field1::read(&storage));
+        assert_eq!(Wrapped(10u32.pow(7)), Field2::read(&storage));
+
+        assert_eq!(
+            Some(4),
+            WrappedField::<u32, Wrapped<u32>, PrimitiveField::<u32, NativeEndian, 5>>::SIZE
+        );
+        assert_eq!(
+            Some(4),
+            WrappedField::<u32, Wrapped<u32>, PrimitiveField::<u32, NativeEndian, 5>>::SIZE
         );
     }
 
@@ -783,6 +1033,38 @@ mod tests {
     }
 
     #[test]
+    fn test_u64_nativeendian() {
+        let mut storage = vec![0; 1024];
+
+        type Field1 = WrappedField<u64, Wrapped<u64>, PrimitiveField<u64, NativeEndian, 5>>;
+        type Field2 = WrappedField<u64, Wrapped<u64>, PrimitiveField<u64, NativeEndian, 20>>;
+
+        Field1::write(&mut storage, Wrapped(10u64.pow(15)));
+        Field2::write(&mut storage, Wrapped(10u64.pow(14)));
+
+        assert_eq!(
+            10u64.pow(15),
+            u64::from_ne_bytes((&storage[5..13]).try_into().unwrap())
+        );
+        assert_eq!(
+            10u64.pow(14),
+            u64::from_ne_bytes((&storage[20..28]).try_into().unwrap())
+        );
+
+        assert_eq!(Wrapped(10u64.pow(15)), Field1::read(&storage));
+        assert_eq!(Wrapped(10u64.pow(14)), Field2::read(&storage));
+
+        assert_eq!(
+            Some(8),
+            WrappedField::<u64, Wrapped<u64>, PrimitiveField::<u64, NativeEndian, 5>>::SIZE
+        );
+        assert_eq!(
+            Some(8),
+            WrappedField::<u64, Wrapped<u64>, PrimitiveField::<u64, NativeEndian, 5>>::SIZE
+        );
+    }
+
+    #[test]
     fn test_u128_littleendian() {
         let mut storage = vec![0; 1024];
 
@@ -843,6 +1125,38 @@ mod tests {
         assert_eq!(
             Some(16),
             WrappedField::<u128, Wrapped<u128>, PrimitiveField::<u128, BigEndian, 5>>::SIZE
+        );
+    }
+
+    #[test]
+    fn test_u128_nativeendian() {
+        let mut storage = vec![0; 1024];
+
+        type Field1 = WrappedField<u128, Wrapped<u128>, PrimitiveField<u128, NativeEndian, 5>>;
+        type Field2 = WrappedField<u128, Wrapped<u128>, PrimitiveField<u128, NativeEndian, 200>>;
+
+        Field1::write(&mut storage, Wrapped(10u128.pow(30)));
+        Field2::write(&mut storage, Wrapped(10u128.pow(28)));
+
+        assert_eq!(
+            10u128.pow(30),
+            u128::from_ne_bytes((&storage[5..21]).try_into().unwrap())
+        );
+        assert_eq!(
+            10u128.pow(28),
+            u128::from_ne_bytes((&storage[200..216]).try_into().unwrap())
+        );
+
+        assert_eq!(Wrapped(10u128.pow(30)), Field1::read(&storage));
+        assert_eq!(Wrapped(10u128.pow(28)), Field2::read(&storage));
+
+        assert_eq!(
+            Some(16),
+            WrappedField::<u128, Wrapped<u128>, PrimitiveField::<u128, NativeEndian, 5>>::SIZE
+        );
+        assert_eq!(
+            Some(16),
+            WrappedField::<u128, Wrapped<u128>, PrimitiveField::<u128, NativeEndian, 5>>::SIZE
         );
     }
 
@@ -911,6 +1225,38 @@ mod tests {
     }
 
     #[test]
+    fn test_f32_nativeendian() {
+        let mut storage = vec![0; 1024];
+
+        type Field1 = WrappedField<f32, Wrapped<f32>, PrimitiveField<f32, NativeEndian, 5>>;
+        type Field2 = WrappedField<f32, Wrapped<f32>, PrimitiveField<f32, NativeEndian, 20>>;
+
+        Field1::write(&mut storage, Wrapped(10f32.powf(8.31)));
+        Field2::write(&mut storage, Wrapped(10f32.powf(7.31)));
+
+        assert_eq!(
+            10f32.powf(8.31),
+            f32::from_ne_bytes((&storage[5..9]).try_into().unwrap())
+        );
+        assert_eq!(
+            10f32.powf(7.31),
+            f32::from_ne_bytes((&storage[20..24]).try_into().unwrap())
+        );
+
+        assert_eq!(Wrapped(10f32.powf(8.31)), Field1::read(&storage));
+        assert_eq!(Wrapped(10f32.powf(7.31)), Field2::read(&storage));
+
+        assert_eq!(
+            Some(4),
+            WrappedField::<f32, Wrapped<f32>, PrimitiveField::<f32, NativeEndian, 5>>::SIZE
+        );
+        assert_eq!(
+            Some(4),
+            WrappedField::<f32, Wrapped<f32>, PrimitiveField::<f32, NativeEndian, 5>>::SIZE
+        );
+    }
+
+    #[test]
     fn test_f64_littleendian() {
         let mut storage = vec![0; 1024];
 
@@ -975,6 +1321,38 @@ mod tests {
     }
 
     #[test]
+    fn test_f64_nativeendian() {
+        let mut storage = vec![0; 1024];
+
+        type Field1 = WrappedField<f64, Wrapped<f64>, PrimitiveField<f64, NativeEndian, 5>>;
+        type Field2 = WrappedField<f64, Wrapped<f64>, PrimitiveField<f64, NativeEndian, 20>>;
+
+        Field1::write(&mut storage, Wrapped(10f64.powf(15.31)));
+        Field2::write(&mut storage, Wrapped(10f64.powf(14.31)));
+
+        assert_eq!(
+            10f64.powf(15.31),
+            f64::from_ne_bytes((&storage[5..13]).try_into().unwrap())
+        );
+        assert_eq!(
+            10f64.powf(14.31),
+            f64::from_ne_bytes((&storage[20..28]).try_into().unwrap())
+        );
+
+        assert_eq!(Wrapped(10f64.powf(15.31)), Field1::read(&storage));
+        assert_eq!(Wrapped(10f64.powf(14.31)), Field2::read(&storage));
+
+        assert_eq!(
+            Some(8),
+            WrappedField::<f64, Wrapped<f64>, PrimitiveField::<f64, NativeEndian, 5>>::SIZE
+        );
+        assert_eq!(
+            Some(8),
+            WrappedField::<f64, Wrapped<f64>, PrimitiveField::<f64, NativeEndian, 5>>::SIZE
+        );
+    }
+
+    #[test]
     fn test_unit_littleendian() {
         let mut storage = vec![0; 1024];
 
@@ -997,6 +1375,23 @@ mod tests {
 
         type Field1 = WrappedField<(), Wrapped<()>, PrimitiveField<(), BigEndian, 5>>;
         type Field2 = WrappedField<(), Wrapped<()>, PrimitiveField<(), BigEndian, 20>>;
+
+        Field1::write(&mut storage, Wrapped(()));
+        Field2::write(&mut storage, Wrapped(()));
+
+        assert_eq!(Wrapped(()), Field1::read(&storage));
+        assert_eq!(Wrapped(()), Field2::read(&storage));
+
+        // Unit is a zero sized type, so the storage should never be mutated.
+        assert_eq!(storage, vec![0; 1024]);
+    }
+
+    #[test]
+    fn test_unit_nativeendian() {
+        let mut storage = vec![0; 1024];
+
+        type Field1 = WrappedField<(), Wrapped<()>, PrimitiveField<(), NativeEndian, 5>>;
+        type Field2 = WrappedField<(), Wrapped<()>, PrimitiveField<(), NativeEndian, 20>>;
 
         Field1::write(&mut storage, Wrapped(()));
         Field2::write(&mut storage, Wrapped(()));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -169,7 +169,7 @@
 //! define_layout!(header, BigEndian, {
 //!     field1: i16,
 //! });
-//! define_layout!(middle, BigEndian, {
+//! define_layout!(middle, NativeEndian, {
 //!     deep: deep_nesting::NestedView,
 //!     field1: u16,
 //! });

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -199,7 +199,7 @@ mod utils;
 
 pub mod example;
 
-pub use endianness::{BigEndian, Endianness, LittleEndian};
+pub use endianness::{BigEndian, Endianness, LittleEndian, NativeEndian};
 pub use fields::{
     primitive::{FieldCopyAccess, FieldSliceAccess, FieldView, PrimitiveField},
     wrapped::{LayoutAs, WrappedField},
@@ -214,7 +214,9 @@ pub use utils::data::Data;
 /// use binary_layout::prelude::*;
 /// ```
 pub mod prelude {
-    pub use super::{BigEndian, Field, FieldCopyAccess, FieldSliceAccess, LittleEndian};
+    pub use super::{
+        BigEndian, Field, FieldCopyAccess, FieldSliceAccess, LittleEndian, NativeEndian,
+    };
     pub use crate::define_layout;
 }
 

--- a/tests/empty.rs
+++ b/tests/empty.rs
@@ -2,5 +2,7 @@ use binary_layout::prelude::*;
 
 #[test]
 fn test_layout_empty() {
-    define_layout!(empty, LittleEndian, {});
+    define_layout!(empty_little, LittleEndian, {});
+    define_layout!(empty_big, BigEndian, {});
+    define_layout!(empty_native, NativeEndian, {});
 }

--- a/tests/endianness.rs
+++ b/tests/endianness.rs
@@ -49,3 +49,26 @@ fn test_big_endian() {
         i64::from_be_bytes((&storage[2..10]).try_into().unwrap())
     );
 }
+
+#[test]
+fn test_native_endian() {
+    define_layout!(my_layout, NativeEndian, {
+        field1: u16,
+        field2: i64,
+    });
+
+    let mut storage = data_region(1024, 0);
+    let mut view = my_layout::View::new(&mut storage);
+    view.field1_mut().write(1000);
+    assert_eq!(1000, view.field1().read());
+    view.field2_mut().write(10i64.pow(15));
+    assert_eq!(10i64.pow(15), view.field2().read());
+    assert_eq!(
+        1000,
+        u16::from_ne_bytes((&storage[0..2]).try_into().unwrap())
+    );
+    assert_eq!(
+        10i64.pow(15),
+        i64::from_ne_bytes((&storage[2..10]).try_into().unwrap())
+    );
+}

--- a/tests/nested.rs
+++ b/tests/nested.rs
@@ -10,7 +10,7 @@ define_layout!(deep_nesting, LittleEndian, {
 define_layout!(header, BigEndian, {
     field1: i16,
 });
-define_layout!(middle, BigEndian, {
+define_layout!(middle, NativeEndian, {
     deep: deep_nesting::NestedView,
     field1: u16,
 });
@@ -62,7 +62,7 @@ fn view_readonly() {
         view.mid().deep().field1().read(),
     );
     assert_eq!(
-        u16::from_be_bytes((&data_region(1024, 5)[12..14]).try_into().unwrap()),
+        u16::from_ne_bytes((&data_region(1024, 5)[12..14]).try_into().unwrap()),
         view.mid().field1().read(),
     );
     assert_eq!(
@@ -108,7 +108,7 @@ fn view_readwrite() {
         view.mid().deep().field1().read(),
     );
     assert_eq!(
-        u16::from_be_bytes((&data_region(1024, 5)[12..14]).try_into().unwrap()),
+        u16::from_ne_bytes((&data_region(1024, 5)[12..14]).try_into().unwrap()),
         view.mid().field1().read(),
     );
     assert_eq!(
@@ -172,7 +172,7 @@ fn view_readwrite() {
     );
     assert_eq!(
         1000,
-        u16::from_be_bytes((&storage[12..14]).try_into().unwrap())
+        u16::from_ne_bytes((&storage[12..14]).try_into().unwrap())
     );
     assert_eq!(
         10_u128.pow(30),
@@ -207,7 +207,7 @@ fn view_vec_readonly() {
         view.mid().deep().field1().read(),
     );
     assert_eq!(
-        u16::from_be_bytes((&data_region(1024, 5)[12..14]).try_into().unwrap()),
+        u16::from_ne_bytes((&data_region(1024, 5)[12..14]).try_into().unwrap()),
         view.mid().field1().read(),
     );
     assert_eq!(
@@ -253,7 +253,7 @@ fn view_vec_readwrite() {
         view.mid().deep().field1().read(),
     );
     assert_eq!(
-        u16::from_be_bytes((&data_region(1024, 5)[12..14]).try_into().unwrap()),
+        u16::from_ne_bytes((&data_region(1024, 5)[12..14]).try_into().unwrap()),
         view.mid().field1().read(),
     );
     assert_eq!(
@@ -311,7 +311,7 @@ fn view_vec_readwrite() {
     );
     assert_eq!(
         1000,
-        u16::from_be_bytes((&extracted_storage[12..14]).try_into().unwrap())
+        u16::from_ne_bytes((&extracted_storage[12..14]).try_into().unwrap())
     );
     assert_eq!(
         10_u128.pow(30),


### PR DESCRIPTION
I built this feature in order to use this library to model in-memory data structures which nest fixed endianness within larger native endian encoded data.

Closes #21