### PR TITLE
Fix no_std compatibility

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,11 +16,11 @@ version = "4.0.1"
 [dependencies]
 doc-comment = "^0.3"
 paste = "^1.0"
-thiserror = "^1.0.29"
+thiserror = { version = "^1.0.29", optional = true }
 
 [dev-dependencies]
 rand = "^0.8"
 
 [features]
 default = ["std"]
-std = []
+std = ["dep:thiserror"]


### PR DESCRIPTION
Under certain build configurations, Rust will build all libraries listed under `[dependencies]` and not just those which are actually used. This change makes thiserror a dependency of the std feature so that doesn't happen.