### PR TITLE
Fixing no-std support by making thiserror optional and added test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,6 +104,34 @@ jobs:
         with:
           command: ${{ matrix.command }}
           args: ${{ matrix.profile }} ${{ matrix.features }}
+  thumbv6m_no_std:
+    name: thumbv6m_no_std
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        command: [ "build" ]
+        profile: [ "", "--release" ]
+        features: [ "--no-default-features" ]
+        # Nightly because -Z direct-minimal-versions is a nightly cargo feature
+        toolchain: [ "nightly" ]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ matrix.toolchain }}
+          target: thumbv6m-none-eabi
+          default: true
+      - uses: actions-rs/cargo@v1
+        with:
+          use-cross: true
+          command: "update"
+          args: "-Z direct-minimal-versions"
+      - uses: actions-rs/cargo@v1
+        with:
+          use-cross: true
+          command: ${{ matrix.command }}
+          args: ${{ matrix.profile }} ${{ matrix.features }} --target thumbv6m-none-eabi
   clippy_check:
     name: Linter (clippy)
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,11 +16,11 @@ version = "4.0.1"
 [dependencies]
 doc-comment = "^0.3"
 paste = "^1.0"
-thiserror = "^1.0.29"
+thiserror = { version = "^1.0.29", optional = true }
 
 [dev-dependencies]
 rand = "^0.8"
 
 [features]
 default = ["std"]
-std = []
+std = ["dep:thiserror"]


### PR DESCRIPTION
ln version 4.0 the thiserror dependency was added to the library. thiserror isn't no-std compatible, and indeed was disabled in the code using the cfg macro. Sadly it wasn't made optional in the cargo.toml which means that is always compiled, even if the std feature of binary-layout has been disabled.